### PR TITLE
nuke redundant import warning on ghc 7.10; enable -Wall

### DIFF
--- a/hakyll-sass.cabal
+++ b/hakyll-sass.cabal
@@ -22,3 +22,4 @@ library
     , hsass >= 0.2.0
   hs-source-dirs: src
   default-language: Haskell2010
+  ghc-options: -Wall

--- a/src/Hakyll/Web/Sass.hs
+++ b/src/Hakyll/Web/Sass.hs
@@ -15,6 +15,7 @@ import Hakyll.Core.Compiler
 import Hakyll.Core.Item
 import Text.Sass.Compilation
 import Text.Sass.Options
+import Prelude
 
 -- | Compiles a SASS file into CSS.
 sassCompiler :: Compiler (Item String)


### PR DESCRIPTION
Signed-off-by: Ricky Elrod ricky@elrod.me
